### PR TITLE
Fix empty new vendor page

### DIFF
--- a/apps/admin/app/(auth)/login/page.tsx
+++ b/apps/admin/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@tradygo/ui';
 import { Button } from '@tradygo/ui';
@@ -15,7 +15,7 @@ interface AppBranding {
   logoUrl: string;
 }
 
-export default function LoginPage() {
+function LoginContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [email, setEmail] = useState('');
@@ -171,5 +171,13 @@ export default function LoginPage() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
Wrap login page content in a Suspense boundary to fix blank page issues on `/admin/vendors/new` and other routes.

The `useSearchParams()` hook was being used directly in the login page component without a Suspense boundary. This caused build failures and incorrect prerendering, leading to blank pages for routes like `/admin/vendors/new` that depend on a successful build or might redirect to the login page. Wrapping the component in Suspense resolves this Next.js-specific issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-700af6c1-6371-45f3-be72-c4d931087165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-700af6c1-6371-45f3-be72-c4d931087165">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

